### PR TITLE
Include missing cmath header to ensure math operations are found

### DIFF
--- a/ProdDigest/HisNorm.cxx
+++ b/ProdDigest/HisNorm.cxx
@@ -5,6 +5,8 @@
 /////////////////////////////////////////////////////////////////////
 #include "HisNorm.h"
 
+#include <cmath>
+
 double sqr( const Double_t x ){ return x*x;};
 
 


### PR DESCRIPTION
Otherwise compilation will not work with recent versions of ROOT and gcc.

edit: this becomes necessary after: https://github.com/root-project/root/pull/19591